### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
       sudo: true
     - python: 3.6
     - python: 3.5
-    - python: 3.4
     - python: 2.7
     - python: pypy
     - os: osx

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, 3.7, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.5, 3.6, 3.7, and for PyPy. Check
    https://travis-ci.org/DiamondLightSource/python-procrunner/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ pip==19.1.1
 pytest==4.5.0 # pyup: <5.0 # for Python 2.7 support
 pytest-runner==5.1
 six==1.12.0
-Sphinx==1.8.5 # pyup: <2.0 # for Python 2.7 and 3.4 support
+Sphinx==1.8.5 # pyup: <2.0 # for Python 2.7 support
 tox==3.13.1
 twine==1.13.0
 watchdog==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "six",
-    # PyWin32 is only supported on 2.7 and 3.5+
-    'pywin32; sys_platform=="win32" and python_version=="2.7"',
-    'pywin32; sys_platform=="win32" and python_version>="3.5"',
+    'pywin32; sys_platform=="win32"',
 ]
 
 setup_requirements = []
@@ -36,7 +34,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, flake8
+envlist = py27, py35, py36, py37, py38, flake8
 
 [travis]
 python =
@@ -7,7 +7,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
not required yet, but will become necessary at some point.