### PR TITLE
Deprecate the debug= parameter

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ History
   list as the first argument) is now deprecated. As a number of arguments
   will be removed in a future version the use of unnamed arguments will
   cause future confusion. `Use explicit keyword arguments instead (#62). <https://github.com/DiamondLightSource/python-procrunner/pull/62>`_
+* The run() function debug argument has been deprecated. This is only
+  only used to debug the NonBlockingStream* classes. Those are due to be
+  replaced in a future release, so the argument will no longer serve a
+  purpose. Debugging information remains available via standard logging
+  mechanisms.
 
 2.1.0 (2020-09-05)
 ------------------

--- a/procrunner/__init__.py
+++ b/procrunner/__init__.py
@@ -488,7 +488,7 @@ def run(
         stdin_pipe = subprocess.PIPE
     if debug is not None:
         warnings.warn(
-            "Use of the debug parameter is deprecated", DeprecationWarning, stacklevel=2
+            "Use of the debug parameter is deprecated", DeprecationWarning, stacklevel=3
         )
 
     start_time = timeit.default_timer()
@@ -498,7 +498,7 @@ def run(
             warnings.warn(
                 "Using procrunner with timeout and without raise_timeout_exception set is deprecated",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
     if environment is not None:

--- a/procrunner/__init__.py
+++ b/procrunner/__init__.py
@@ -210,7 +210,6 @@ class _NonBlockingStreamWriter:
         self._buffer = data
         self._buffer_len = len(data)
         self._buffer_pos = 0
-        self._debug = debug
         self._max_block_len = 4096
         self._stream = stream
         self._terminated = False
@@ -433,7 +432,7 @@ def _deprecate_argument_calling(f):
 def run(
     command,
     timeout=None,
-    debug=False,
+    debug=None,
     stdin=None,
     print_stdout=True,
     print_stderr=True,
@@ -453,7 +452,7 @@ def run(
 
     :param array command: Command line to be run, specified as array.
     :param timeout: Terminate program execution after this many seconds.
-    :param boolean debug: Enable further debug messages.
+    :param boolean debug: Enable further debug messages. (deprecated)
     :param stdin: Optional bytestring that is passed to command stdin.
     :param boolean print_stdout: Pass stdout through to sys.stdout.
     :param boolean print_stderr: Pass stderr through to sys.stderr.
@@ -487,6 +486,10 @@ def run(
     else:
         assert sys.platform != "win32", "stdin argument not supported on Windows"
         stdin_pipe = subprocess.PIPE
+    if debug is not None:
+        warnings.warn(
+            "Use of the debug parameter is deprecated", DeprecationWarning, stacklevel=2
+        )
 
     start_time = timeit.default_timer()
     if timeout is not None:


### PR DESCRIPTION
This is currently only used for NBSR/NBSW debugging, and otherwise
superseded by python logging framework functionality.
It's likely that NBSR/NBSW are on their way out, thus in a future
release this keyword argument will be removed.